### PR TITLE
test: add walk test for LEDs, fix kernel includes

### DIFF
--- a/driver/daisy.c
+++ b/driver/daisy.c
@@ -24,6 +24,7 @@
 #include <linux/delay.h>
 #include <linux/slab.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 
 #include <asm/current.h>
 #include <asm/uaccess.h>

--- a/driver/ieee1284.c
+++ b/driver/ieee1284.c
@@ -24,6 +24,7 @@
 #include <linux/interrupt.h>
 #include <linux/timer.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 
 #undef DEBUG /* undef me for production */
 

--- a/driver/ieee1284_ops.c
+++ b/driver/ieee1284_ops.c
@@ -18,6 +18,7 @@
 #include <linux/parport.h>
 #include <linux/delay.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <asm/uaccess.h>
 
 #undef DEBUG /* undef me for production */

--- a/driver/lp.c
+++ b/driver/lp.c
@@ -118,6 +118,7 @@
 #include <linux/kernel.h>
 #include <linux/major.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <linux/slab.h>
 #include <linux/fcntl.h>
 #include <linux/delay.h>

--- a/driver/ppdev.c
+++ b/driver/ppdev.c
@@ -59,6 +59,7 @@
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <linux/device.h>
 #include <linux/ioctl.h>
 #include <linux/parport.h>

--- a/driver/procfs.c
+++ b/driver/procfs.c
@@ -23,7 +23,7 @@
 #include <linux/sysctl.h>
 #include <linux/device.h>
 
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 
 #if defined(CONFIG_SYSCTL) && defined(CONFIG_PROC_FS)
 

--- a/driver/share.c
+++ b/driver/share.c
@@ -30,6 +30,7 @@
 #include <linux/sched.h>
 #include <linux/kmod.h>
 #include <linux/device.h>
+#include <linux/sched/signal.h>
 
 #include <linux/spinlock.h>
 #include <linux/mutex.h>

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-PROGS = cableTest2 loop
+PROGS = cableTest2 loop walk
 
 all: $(PROGS)
 

--- a/test/loop.c
+++ b/test/loop.c
@@ -27,7 +27,6 @@
 
 #define DEVICE_PATH "/dev/parport0"
 #define ITERATIONS 16
-#define RITERATIONS 1
 
 void die (const char *fmt, ...)
 {
@@ -57,6 +56,8 @@ int main (int argc, char *argv[])
     if (ioctl (fd, PPSETMODE, &mode) < 0)
         die ("ioctl PPSETMODE IEEE1284_MODE_BYTE: %s\n", strerror (errno));
 
+    /* DATA[2,4:7] => STATUS[3,4:7]
+     */
     dir = 0;
     if (ioctl (fd, PPDATADIR, &dir) < 0)
         die ("ioctl PPDATADIR 0 (out): %s\n", strerror (errno));
@@ -96,20 +97,21 @@ int main (int argc, char *argv[])
     }
     printf ("%d errors\n", errors);
 
-#if 0
+    /* CONTROL[1,3] => DATA[1,3]
+     */
     dir = 1;
     if (ioctl (fd, PPDATADIR, &dir) < 0)
         die ("ioctl PPDATADIR 1 (in): %s\n", strerror (errno));
     printf ("data in reverse mode\n");
 
-    printf("Check CONTROL[1,3] => DATA[1,3] (%d iterations)\n", RITERATIONS);
+    printf("Check CONTROL[1,3] => DATA[1,3] (%d iterations)\n", ITERATIONS);
 
     errors = 0;
-    for (iter = 0; iter < RITERATIONS; iter++) {
+    for (iter = 0; iter < ITERATIONS; iter++) {
         for (i = 0; i < 16; i++) {
             out = i;
             if (ioctl (fd, PPWCONTROL, &out) < 0)
-                die ("ioctl PPWCONTROL: %s\n", strerror (errno));
+               die ("ioctl PPWCONTROL: %s\n", strerror (errno));
             if (ioctl (fd, PPRDATA, &in) < 0)
                 die ("ioctl PPRDATA: %s\n", strerror (errno));
             if ((out & (1<<1)) == (in & (1<<1))) { // CONTROL1 inverted
@@ -123,7 +125,6 @@ int main (int argc, char *argv[])
         }
     }
     printf ("%d errors\n", errors);
-#endif
 
     if (ioctl (fd, PPRELEASE) < 0)
         die ("ioctl PPRELEASE: %s\n", strerror (errno));

--- a/test/walk.c
+++ b/test/walk.c
@@ -1,0 +1,131 @@
+/* walk - visual LED output test
+ *
+ * DATA0 (2)
+ * DATA1 (3)
+ * DATA2 (4)
+ * DATA3 (5)
+ * DATA4 (6)
+ * DATA5 (7)
+ * DATA6 (8)
+ * DATA7 (9)
+ * CONTROL0 (1) ~nStrobe
+ * CONTROL1 (14) ~nAutoLF
+ * CONTROL2 (16) nInitialize
+ * CONTROL3 (17) ~nSelect
+ */
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <linux/parport.h>
+#include <linux/ppdev.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <string.h>
+
+#define DEVICE_PATH "/dev/parport0"
+
+const int invert_outputs = 1; // set to 1 if LED's tied to 5V, 0 if tied to GND
+
+void die (const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start (ap, fmt);
+    (void)vfprintf (stderr, fmt, ap);
+    va_end (ap);
+    exit (1);
+}
+
+void out_data (int fd, int out)
+{
+    if (invert_outputs)
+        out = ~out;
+    if (ioctl (fd, PPWDATA, &out) < 0)
+        die ("ioctl PPWDATA: %s\n", strerror (errno));
+}
+
+void wiggle_data (int fd, int out)
+{
+    int i;
+    int d = 0;
+    out_data (fd, 0);
+    for (i = 0; i < 16; i++) {
+        out_data (fd, out & d);
+        usleep (100*1000); // 100ms
+        d = ~d;
+    }
+    out_data (fd, 0);
+}
+
+void out_control (int fd, int out)
+{
+    out ^= (1<<0); // invert ~nStrope
+    out ^= (1<<1); // invert ~nAutolf
+    out ^= (1<<3); // invert ~nSelect
+    if (invert_outputs)
+        out = ~out;
+    out &= 0x0f; // don't set upper 4 bits of CONTROL
+    if (ioctl (fd, PPWCONTROL, &out) < 0)
+        die ("ioctl PPWCONTROL: %s\n", strerror (errno));
+}
+
+void wiggle_control (int fd, int out)
+{
+    int i;
+    int d = 0;
+    out_control (fd, 0);
+    for (i = 0; i < 16; i++) {
+        out_control (fd, out & d);
+        usleep (100*1000); // 100ms
+        d = ~d;
+    }
+    out_control (fd, 0);
+}
+
+int main (int argc, char *argv[])
+{
+    int fd, mode, dir;
+    unsigned char out;
+    unsigned char in;
+    int iter, i, j;
+    int errors;
+
+    fd = open (DEVICE_PATH, O_RDWR);
+    if (fd < 0)
+        die ("%s: %s\n", DEVICE_PATH, strerror (errno));
+    if (ioctl (fd, PPCLAIM, NULL) < 0)
+        die ("ioctl PPCLAIM: %s\n", strerror (errno));
+
+    mode = IEEE1284_MODE_BYTE;
+    if (ioctl (fd, PPSETMODE, &mode) < 0)
+        die ("ioctl PPSETMODE IEEE1284_MODE_BYTE: %s\n", strerror (errno));
+    dir = 0;
+    if (ioctl (fd, PPDATADIR, &dir) < 0)
+        die ("ioctl PPDATADIR 0 (set output): %s\n", strerror (errno));
+
+    out_data (fd, 0);
+    out_control (fd, 0);
+
+    sleep (2);
+
+    for (i = 0; i < 8; i++)
+        wiggle_data (fd, 1<<i);
+    for (i = 0; i < 4; i++)
+        wiggle_control (fd, 1<<i);
+
+    sleep (2);
+
+    if (ioctl (fd, PPRELEASE) < 0)
+        die ("ioctl PPRELEASE: %s\n", strerror (errno));
+    if (close(fd) < 0)
+        die ("close %s: %s\n", DEVICE_PATH, strerror (errno));
+
+   return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR adds a ppdev test for LEDs attached to all DATA and CONTROL outputs.  It also uncomments a section of the loop test, and makes minor changes to kernel includes to compile with latest rpi kernel headers.